### PR TITLE
change to underscore in package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
 
-setup(name='nmt-keras',
+setup(name='nmt_keras',
       version='0.6',
       description='Neural Machine Translation with Keras (Theano and Tensorflow).',
       author='Marc Bolaños - Alvaro Peris',


### PR DESCRIPTION
Fixing package name in setup.py from `nmt-keras` (not importable in python) to `nmt_keras` (which is).
My mistake in the previous PR, apologies.