### PR TITLE
Packaging fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
 
-setup(name='nmt-keras',
+setup(name='nmt_keras',
       version='0.6',
       description='Neural Machine Translation with Keras (Theano and Tensorflow).',
       author='Marc Bolaños - Alvaro Peris',
@@ -9,7 +9,6 @@ setup(name='nmt-keras',
       url='https://github.com/lvapeab/nmt-keras',
       download_url='https://github.com/lvapeab/nmt-keras/archive/master.zip',
       license='MIT',
-      packages=setuptools.find_packages(),
       classifiers=[
           'Intended Audience :: Developers',
           'Intended Audience :: Education',
@@ -43,5 +42,6 @@ setup(name='nmt-keras',
           'sacremoses',
           'scipy',
           'tensorflow<2'
-      ]
+      ],
+      packages=setuptools.find_packages()
       )

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,19 @@ setup(name='nmt_keras',
           'scipy',
           'tensorflow<2'
       ],
-      packages=setuptools.find_packages()
+      package_dir={'nmt_keras':'.',
+                   'nmt_keras.utils':'utils',
+                   'nmt_keras.data_engine':'data_engine',
+                   'nmt_keras.nmt_keras':'nmt_keras',
+                   'nmt_keras.demo-web':'demo-web',
+                   },
+      packages=['nmt_keras',
+                'nmt_keras.utils',
+                'nmt_keras.data_engine',
+                'nmt_keras.nmt_keras',
+                'nmt_keras.demo-web'
+      ],
+      package_data={
+                'nmt_keras': ['examples/*']
+      }
       )

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(name='nmt-keras',
       url='https://github.com/lvapeab/nmt-keras',
       download_url='https://github.com/lvapeab/nmt-keras/archive/master.zip',
       license='MIT',
+      packages=setuptools.find_packages(),
       classifiers=[
           'Intended Audience :: Developers',
           'Intended Audience :: Education',


### PR DESCRIPTION
Hey, sorry another one from me.

I realised that the way setup.py was structured before didn't actually work because of the directory arrangement of NMT-Keras.

This version now definitely works and makes NMT-Keras an importable python package, eg things like
```python
from nmt_keras.utils.utils import update_parameters
```
now work.

If you want to include any more non-python parts of the repo in the python package, then they will need to be added to `package_data` in the setup.py.