### PR TITLE
Solved a problem with BPE.

### DIFF
--- a/interactive_char_nmt_simulation.py
+++ b/interactive_char_nmt_simulation.py
@@ -46,9 +46,9 @@ def parse_args():
     parser.add_argument("--max-n", type=int, default=5, help="Maximum number of words generated between isles")
     parser.add_argument("-src", "--source", help="File of source hypothesis", required=True)
     parser.add_argument("-trg", "--references", help="Reference sentence (for simulation)", required=True)
-    parser.add_argument("-bpe-tok", "--tokenize-bpe", help="Apply BPE tokenization", action='store_true', default=True)
+    parser.add_argument("-bpe-tok", "--tokenize-bpe", help="Apply BPE tokenization", action='store_true', default=False)
     parser.add_argument("-bpe-detok", "--detokenize-bpe", help="Revert BPE tokenization",
-                        action='store_true', default=True)
+                        action='store_true', default=False)
     parser.add_argument("-tok-ref", "--tokenize-references", help="Tokenize references. If set to False, the references"
                                                                   "should be given already preprocessed/tokenized.",
                         action='store_true', default=False)

--- a/interactive_nmt_simulation.py
+++ b/interactive_nmt_simulation.py
@@ -48,9 +48,9 @@ def parse_args():
     parser.add_argument("--max-n", type=int, default=3, help="Maximum number of words generated between isles")
     parser.add_argument("-src", "--source", help="File of source hypothesis", required=True)
     parser.add_argument("-trg", "--references", help="Reference sentence (for simulation)", required=True)
-    parser.add_argument("-bpe-tok", "--tokenize-bpe", help="Apply BPE tokenization", action='store_true', default=True)
+    parser.add_argument("-bpe-tok", "--tokenize-bpe", help="Apply BPE tokenization", action='store_true', default=False)
     parser.add_argument("-bpe-detok", "--detokenize-bpe", help="Revert BPE tokenization",
-                        action='store_true', default=True)
+                        action='store_true', default=False)
     parser.add_argument("-tok-ref", "--tokenize-references", help="Tokenize references. If set to False, the references"
                                                                   "should be given already preprocessed/tokenized.",
                         action='store_true', default=False)


### PR DESCRIPTION
The flags "-bpe-tok" and "-bpe-detok" were set to "True" by default, loosing their purpose. Moreover, due to these flags always being activated, independently of the tokenization method set on the config file, the method was being changed to "tokenize_bpe"--making the use of BPE mandatory.

I've changed their default value to "False" so that you can either select your desired tokenization method on the config file (or with the "changes" argument) or active those flags to use BPE accordingly to your needs.